### PR TITLE
Create GitHub workflow to build and publish Docker image

### DIFF
--- a/.github/workflows/build-and-publish-docker.yml
+++ b/.github/workflows/build-and-publish-docker.yml
@@ -1,0 +1,34 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
Related to #1

Add a GitHub Actions workflow to build and publish Docker image.

* Create a new GitHub Actions workflow file `.github/workflows/build-and-publish-docker.yml`.
* Define the workflow to trigger on push and pull request events for the `main` branch.
* Add steps to check out the repository, set up Docker Buildx, log in to GitHub Container Registry, and build and push the Docker image to `ghcr.io`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/YOUSIKI/Instant-Marchkov/issues/1?shareId=ad768213-b50d-4d93-8488-fd5e46f106b2).